### PR TITLE
[Fix] Zip naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperplay/cli",
-  "version": "2.9.2",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperplay/cli",
-      "version": "2.9.2",
+      "version": "2.10.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@oclif/core": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/cli",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Hyperplay CLI",
   "author": "HyperPlay Labs, Inc.",
   "bin": {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -113,9 +113,7 @@ export default class Publish extends Command {
       this.error(`release ${config.release} exists`);
     }
 
-    CliUx.ux.action.start('uploading files');
     const release = await uploadRelease(valist, config, yamlConfig);
-    CliUx.ux.action.stop();
     CliUx.ux.log(`successfully uploaded files to IPFS: ${release.external_url}`);
 
     CliUx.ux.action.start('publishing release');

--- a/src/utils/getZipName.ts
+++ b/src/utils/getZipName.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+
+export function getZipName(filePath: string){
+    const zipName = path.basename(path.resolve(filePath), path.extname(filePath))
+    return `./${zipName}.zip`;
+}

--- a/test/utils/getZipName.test.ts
+++ b/test/utils/getZipName.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { getZipName } from '../../src/utils/getZipName'
+
+describe('Zip Name Tests', ()=>{
+    it('should get the folder name when zipping the same folder as hyperplay.yml', ()=>{
+        const name = getZipName('.').toLowerCase()
+        expect(name).to.eq('./cli.zip')
+    })
+
+    it('should get the folder name for subdirectory path', ()=>{
+        const name = getZipName('../mock_data/windows_amd64')
+        expect(name).to.eq('./windows_amd64.zip')
+    })
+
+    it('should get the file name for file path', ()=>{
+        const name = getZipName('../mock_data/dmg.txt')
+        expect(name).to.eq('./dmg.zip')
+    })
+})


### PR DESCRIPTION
Previously zipping the same directory as hyperplay.yml with `.` as the pathname would name the zip `..zip` which can be confusing

This fixes this, using the directory name in this case. It also breaks this function out into a separate module and adds a unit test for it