### PR TITLE
[Fix] Fix the Valist sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/cli",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "description": "Hyperplay CLI",
   "author": "HyperPlay Labs, Inc.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@oclif/core": "^1.8.0",
     "@oclif/plugin-help": "^5",
-    "@valist/sdk": "^2.9.5",
+    "@valist/sdk": "2.9.5",
     "archiver": "^7.0.0",
     "axios": "^1.6.7",
     "axios-cookiejar-support": "^5.0.0",


### PR DESCRIPTION
When installing globally, valist sdk 2.9.6 is installed which breaks the create fxn since it expects an ether v6 signer to be passed in. We need to fix it to 2.9.5 to use the v5 signer logic.